### PR TITLE
Cache control, stale-while-revalidate

### DIFF
--- a/infra/entries-api-gateway.tf
+++ b/infra/entries-api-gateway.tf
@@ -4,9 +4,10 @@ resource "aws_apigatewayv2_api" "t-rss-reader-entries-handler-api" {
 
   cors_configuration {
     allow_origins     = var.t-rss-reader-allow-origins
-    allow_methods     = ["POST"]
+    allow_methods     = ["GET"]
     allow_headers     = ["content-type", "authorization"]
     allow_credentials = true
+    max_age           = 600
   }
 }
 
@@ -45,8 +46,8 @@ resource "aws_apigatewayv2_integration" "t-rss-reader-entries-handler-api-integr
   integration_uri    = aws_lambda_function.t-rss-reader-entries-handler.invoke_arn
 }
 
-resource "aws_apigatewayv2_route" "t-rss-reader-entries-handler-api-route-post" {
+resource "aws_apigatewayv2_route" "t-rss-reader-entries-handler-api-route-get" {
   api_id    = aws_apigatewayv2_api.t-rss-reader-entries-handler-api.id
-  route_key = "POST /entries"
+  route_key = "GET /entries"
   target    = "integrations/${aws_apigatewayv2_integration.t-rss-reader-entries-handler-api-integration.id}"
 }

--- a/infra/entries-handler/test/fixture/create-event.ts
+++ b/infra/entries-handler/test/fixture/create-event.ts
@@ -3,7 +3,10 @@ import type { APIGatewayEvent, APIGatewayEventRequestContext } from 'aws-lambda'
 const event: APIGatewayEvent = {
   path: 'entries',
   resource: 'entries',
-  httpMethod: 'POST',
+  queryStringParameters: {
+    url: 'https%3A%2F%2Ftyhopp.com%2Frss.xml'
+  },
+  httpMethod: 'GET',
   body: '{}',
   headers: {
     'Content-Type': 'application/json'
@@ -11,16 +14,14 @@ const event: APIGatewayEvent = {
   multiValueHeaders: {},
   isBase64Encoded: false,
   pathParameters: null,
-  queryStringParameters: null,
   multiValueQueryStringParameters: null,
   stageVariables: null,
   requestContext: {} as APIGatewayEventRequestContext
 };
 
 export function createEvent(
-  httpMethod: string = 'POST',
-  body: Record<string, unknown> = {}
+  queryStringParameters: Record<string, string> = event.queryStringParameters,
+  httpMethod: string = 'GET'
 ): APIGatewayEvent {
-  const stringifiedBody = JSON.stringify(body);
-  return { ...event, httpMethod, body: stringifiedBody };
+  return { ...event, queryStringParameters, httpMethod };
 }

--- a/infra/entries-handler/test/index.test.ts
+++ b/infra/entries-handler/test/index.test.ts
@@ -33,23 +33,20 @@ test('should return early if user is not authorized', async () => {
   expect(body).toMatch('Unauthorized');
 });
 
-test('should return early if request body is malformed', async () => {
+test('should return early if url query param is malformed', async () => {
   vi.mocked(verifyToken).mockReturnValueOnce(true);
-  const event = createEvent();
-  event.body = 'invalid-json';
+  const event = createEvent({ url: '%' });
 
   const { statusCode, body } = await handler(event);
 
   expect(statusCode).toEqual(400);
-  expect(body).toMatch('Malformed request body');
+  expect(body).toMatch('Malformed url query parameter');
 });
 
-test('should handle POST requests', async () => {
+test('should handle GET requests', async () => {
   vi.mocked(verifyToken).mockReturnValueOnce(true);
   vi.mocked(parseFeed).mockReturnValueOnce([entry]);
-  const event = createEvent('POST', {
-    url: ''
-  });
+  const event = createEvent();
 
   const { statusCode, body } = await handler(event);
   const parsedBody = JSON.parse(body);
@@ -60,7 +57,7 @@ test('should handle POST requests', async () => {
 
 test('should reject unsupported methods', async () => {
   vi.mocked(verifyToken).mockReturnValueOnce(true);
-  const event = createEvent('PATCH', {});
+  const event = createEvent(undefined, 'PATCH');
 
   const { statusCode, body } = await handler(event);
 

--- a/infra/feeds-api-gateway.tf
+++ b/infra/feeds-api-gateway.tf
@@ -7,6 +7,7 @@ resource "aws_apigatewayv2_api" "t-rss-reader-feeds-handler-api" {
     allow_methods     = ["DELETE", "GET", "PUT"]
     allow_headers     = ["content-type", "authorization"]
     allow_credentials = true
+    max_age           = 7200
   }
 }
 

--- a/web/svelte/src/lib/services/entries-service.ts
+++ b/web/svelte/src/lib/services/entries-service.ts
@@ -25,18 +25,15 @@ export class EntriesServiceImpl {
 
   async getEntries(url: string, abortController?: AbortController): Promise<Response> {
     const options: RequestInit = {
-      method: 'POST',
-      headers: this.headersWithAuthorization(),
-      body: JSON.stringify({
-        url
-      })
+      method: 'GET',
+      headers: this.headersWithAuthorization()
     };
 
     if (abortController) {
       options.signal = abortController.signal;
     }
 
-    return await fetch(PUBLIC_ENTRIES_API, options);
+    return await fetch(`${PUBLIC_ENTRIES_API}?url=${encodeURIComponent(url)}`, options);
   }
 }
 


### PR DESCRIPTION
Adjust HTTP cache for `/feeds` and `/entries` endpoints. Also adjust `/entries` endpoint to accept feed urls via query param so each request is cached