### PR TITLE
All entries worker

### DIFF
--- a/web/svelte/package-lock.json
+++ b/web/svelte/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "t-rss-reader-svelte",
       "version": "0.0.1",
+      "dependencies": {
+        "idb-keyval": "^6.2.0"
+      },
       "devDependencies": {
         "@sveltejs/adapter-static": "^2.0.1",
         "@sveltejs/kit": "^1.5.0",
@@ -1338,6 +1341,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.0.tgz",
+      "integrity": "sha512-uw+MIyQn2jl3+hroD7hF8J7PUviBU7BPKWw4f/ISf32D4LoGu98yHjrzWWJDASu9QNrX10tCJqk9YY0ClWm8Ng==",
+      "dependencies": {
+        "safari-14-idb-fix": "^3.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -2169,6 +2180,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/safari-14-idb-fix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     },
     "node_modules/sander": {
       "version": "0.5.1",

--- a/web/svelte/package.json
+++ b/web/svelte/package.json
@@ -14,6 +14,9 @@
     "lint": "prettier --plugin-search-dir . --check .",
     "format": "prettier --plugin-search-dir . --write ."
   },
+  "dependencies": {
+    "idb-keyval": "^6.2.0"
+  },
   "devDependencies": {
     "@sveltejs/adapter-static": "^2.0.1",
     "@sveltejs/kit": "^1.5.0",

--- a/web/svelte/src/lib/components/Header.svelte
+++ b/web/svelte/src/lib/components/Header.svelte
@@ -10,7 +10,9 @@
   let selectedFeed: Feed | undefined;
 
   onMount(() => {
-    tokenStore.subscribe(({ maybeValid }) => {
+    tokenStore.subscribe((store) => {
+      const { maybeValid } = store || {};
+
       if (maybeValid) {
         disabled = false;
       }

--- a/web/svelte/src/lib/constants.ts
+++ b/web/svelte/src/lib/constants.ts
@@ -1,1 +1,1 @@
-export const LOCAL_STORAGE_ACCESS_TOKEN_KEY = 't-rss-reader-access-token';
+export const ACCESS_TOKEN_KEY = 't-rss-reader-access-token';

--- a/web/svelte/src/lib/services/entries-service.ts
+++ b/web/svelte/src/lib/services/entries-service.ts
@@ -1,7 +1,18 @@
 import { getAccessToken } from '../utils/get-access-token';
-import { PUBLIC_ENTRIES_API } from '$env/static/public';
 
-export class EntriesServiceImpl {
+/**
+ * This service does not export a singleton like the others because it
+ * is also used in a worker context that does not have access to env vars.
+ *
+ * Instead the endpoint should be provided when the service is constructed.
+ */
+export default class EntriesService {
+  constructor(api: string) {
+    this.api = api;
+  }
+
+  private api: string;
+
   private get headers(): HeadersInit {
     return {
       'content-type': 'application/json'
@@ -33,11 +44,8 @@ export class EntriesServiceImpl {
       options.signal = abortController.signal;
     }
 
-    return await fetch(`${PUBLIC_ENTRIES_API}?url=${encodeURIComponent(url)}`, options);
+    const composedUrl = `${this.api}?url=${encodeURIComponent(url)}`;
+
+    return await fetch(composedUrl, options);
   }
 }
-
-const EntriesServiceInstance = new EntriesServiceImpl();
-const EntriesServiceSingleton = Object.freeze(EntriesServiceInstance);
-
-export default EntriesServiceSingleton;

--- a/web/svelte/src/lib/services/entries-service.ts
+++ b/web/svelte/src/lib/services/entries-service.ts
@@ -1,4 +1,4 @@
-import { LOCAL_STORAGE_ACCESS_TOKEN_KEY } from '../constants';
+import { getAccessToken } from '../utils/get-access-token';
 import { PUBLIC_ENTRIES_API } from '$env/static/public';
 
 export class EntriesServiceImpl {
@@ -8,8 +8,8 @@ export class EntriesServiceImpl {
     };
   }
 
-  private headersWithAuthorization(): HeadersInit {
-    const token = localStorage.getItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY);
+  private async headersWithAuthorization(): Promise<HeadersInit> {
+    const token = await getAccessToken();
 
     if (!token) {
       return this.headers;
@@ -26,7 +26,7 @@ export class EntriesServiceImpl {
   async getEntries(url: string, abortController?: AbortController): Promise<Response> {
     const options: RequestInit = {
       method: 'GET',
-      headers: this.headersWithAuthorization()
+      headers: await this.headersWithAuthorization()
     };
 
     if (abortController) {

--- a/web/svelte/src/lib/services/feeds-service.ts
+++ b/web/svelte/src/lib/services/feeds-service.ts
@@ -1,4 +1,4 @@
-import { LOCAL_STORAGE_ACCESS_TOKEN_KEY } from '../constants';
+import { getAccessToken } from '../utils/get-access-token';
 import { PUBLIC_FEEDS_API } from '$env/static/public';
 
 export class FeedsServiceImpl {
@@ -8,8 +8,8 @@ export class FeedsServiceImpl {
     };
   }
 
-  private headersWithAuthorization(): HeadersInit {
-    const token = localStorage.getItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY);
+  private async headersWithAuthorization(): Promise<HeadersInit> {
+    const token = await getAccessToken();
 
     if (!token) {
       return this.headers;
@@ -24,24 +24,30 @@ export class FeedsServiceImpl {
   }
 
   async deleteFeed(url: string): Promise<Response> {
+    const headers = await this.headersWithAuthorization();
+
     return await fetch(PUBLIC_FEEDS_API, {
       method: 'DELETE',
-      headers: this.headersWithAuthorization(),
+      headers,
       body: JSON.stringify({ url })
     });
   }
 
   async getFeeds(): Promise<Response> {
+    const headers = await this.headersWithAuthorization();
+
     return await fetch(PUBLIC_FEEDS_API, {
       method: 'GET',
-      headers: this.headersWithAuthorization()
+      headers
     });
   }
 
   async putFeed(url: string, name: string): Promise<Response> {
+    const headers = await this.headersWithAuthorization();
+
     return await fetch(PUBLIC_FEEDS_API, {
       method: 'PUT',
-      headers: this.headersWithAuthorization(),
+      headers,
       body: JSON.stringify({ url, name })
     });
   }

--- a/web/svelte/src/lib/stores/token-store.ts
+++ b/web/svelte/src/lib/stores/token-store.ts
@@ -1,7 +1,8 @@
 import { writable } from 'svelte/store';
-import { getAccessToken } from '../utils/get-access-token';
+import { getAccessTokenWithCheck } from '../utils/get-access-token';
 import { tokenMaybeValid } from '../utils/token-maybe-valid';
-import { LOCAL_STORAGE_ACCESS_TOKEN_KEY } from '../constants';
+import { ACCESS_TOKEN_KEY } from '../constants';
+import { set } from 'idb-keyval';
 import type { Token } from '../types';
 
 interface TokenStore {
@@ -9,14 +10,17 @@ interface TokenStore {
   token?: Token;
 }
 
-const { maybeValid, token } = getAccessToken();
-
-const tokenStoreInstance = writable<TokenStore>({ maybeValid, token });
+const tokenStoreInstance = writable<TokenStore>();
 
 export const tokenStore = {
+  init: async (): Promise<boolean> => {
+    const { maybeValid, token } = await getAccessTokenWithCheck();
+    tokenStoreInstance.set({ maybeValid, token });
+    return true;
+  },
   subscribe: tokenStoreInstance.subscribe,
-  set: (token: Token) => {
-    localStorage.setItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY, JSON.stringify(token));
+  set: async (token: Token) => {
+    await set(ACCESS_TOKEN_KEY, JSON.stringify(token));
     const maybeValid = tokenMaybeValid(token);
     tokenStoreInstance.set({ maybeValid, token });
   }

--- a/web/svelte/src/lib/utils/get-access-token.ts
+++ b/web/svelte/src/lib/utils/get-access-token.ts
@@ -1,13 +1,18 @@
-import { LOCAL_STORAGE_ACCESS_TOKEN_KEY } from '../constants';
+import { ACCESS_TOKEN_KEY } from '../constants';
+import { get } from 'idb-keyval';
 import { tokenMaybeValid } from './token-maybe-valid';
 import type { Token } from '../types';
 
-export function getAccessToken(): {
+export async function getAccessToken(): Promise<string | undefined> {
+  return await get(ACCESS_TOKEN_KEY);
+}
+
+export async function getAccessTokenWithCheck(): Promise<{
   maybeValid: boolean;
   token?: Token;
-} {
+}> {
   try {
-    const token = localStorage.getItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY);
+    const token = await getAccessToken();
 
     if (token) {
       const parsedToken: Token = JSON.parse(token) || {};

--- a/web/svelte/src/lib/widgets/Details.svelte
+++ b/web/svelte/src/lib/widgets/Details.svelte
@@ -8,6 +8,7 @@
   import { selectedFeedStore } from '../stores/selected-feed-store';
   import { getRandomNumber } from '../utils/get-random-number';
   import type { RssFeedEntries } from '../types';
+  import { PUBLIC_ENTRIES_API } from '$env/static/public';
 
   let loading: boolean = false;
   let selected: boolean = false;
@@ -41,9 +42,11 @@
       entriesFailed = false;
       entries = [];
 
+      const entriesService = new EntriesService(PUBLIC_ENTRIES_API);
       abortController = new AbortController();
 
-      EntriesService.getEntries(nextSelected.url, abortController)
+      entriesService
+        .getEntries(nextSelected.url, abortController)
         .then((response) => response.json())
         .then((nextEntries) => {
           if (!nextEntries) {

--- a/web/svelte/src/lib/widgets/LoginForm.svelte
+++ b/web/svelte/src/lib/widgets/LoginForm.svelte
@@ -26,7 +26,7 @@
 
       if (response.status === 200 && 'accessToken' in body) {
         result = Result.success;
-        tokenStore.set(body);
+        await tokenStore.set(body);
         location.assign('/');
       } else {
         result = Result.failure;

--- a/web/svelte/src/lib/workers/all-entries-worker.ts
+++ b/web/svelte/src/lib/workers/all-entries-worker.ts
@@ -1,4 +1,4 @@
-import EntiesService from '../services/entries-service';
+import EntriesService from '../services/entries-service';
 
 class AbortTimeoutController extends AbortController {
   get signal() {
@@ -7,9 +7,10 @@ class AbortTimeoutController extends AbortController {
 }
 
 onmessage = async (event: MessageEvent): Promise<void> => {
-  const urls: Array<string> = event.data;
+  const { api, urls }: { api: string; urls: Array<string> } = event.data || {};
   const controller: AbortController = new AbortTimeoutController();
-  const requests = urls.map((url: string) => EntiesService.getEntries(url, controller));
+  const service: EntriesService = new EntriesService(api);
+  const requests = urls.map((url: string) => service.getEntries(url, controller));
   await Promise.allSettled(requests);
 };
 

--- a/web/svelte/src/lib/workers/all-entries-worker.ts
+++ b/web/svelte/src/lib/workers/all-entries-worker.ts
@@ -1,0 +1,16 @@
+import EntiesService from '../services/entries-service';
+
+class AbortTimeoutController extends AbortController {
+  get signal() {
+    return AbortSignal.timeout(3000);
+  }
+}
+
+onmessage = async (event: MessageEvent): Promise<void> => {
+  const urls: Array<string> = event.data;
+  const controller: AbortController = new AbortTimeoutController();
+  const requests = urls.map((url: string) => EntiesService.getEntries(url, controller));
+  await Promise.allSettled(requests);
+};
+
+export {};

--- a/web/svelte/src/routes/+page.svelte
+++ b/web/svelte/src/routes/+page.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { tokenStore } from '$lib/stores/token-store';
+  import { feedsStore } from '$lib/stores/feeds-store';
   import List from '$lib/widgets/List.svelte';
   import Details from '$lib/widgets/Details.svelte';
   import UpsertFeedModal from '$lib/widgets/UpsertFeedModal.svelte';
+  import AllEntriesWorker from '$lib/workers/all-entries-worker?worker';
 
-  onMount(() => {
-    tokenStore.subscribe(({ maybeValid }) => {
-      if (!maybeValid) {
+  onMount(async () => {
+    const initialized = await tokenStore.init();
+
+    tokenStore.subscribe((store) => {
+      const { maybeValid } = store || {};
+
+      if (initialized && !maybeValid) {
         location.assign('/login');
+      }
+    });
+
+    feedsStore.subscribe((feeds) => {
+      if (feeds.length) {
+        const urls = feeds.map((feed) => feed.url);
+        const allEntriesWorker = new AllEntriesWorker();
+        allEntriesWorker.postMessage(urls);
       }
     });
   });

--- a/web/svelte/src/routes/+page.svelte
+++ b/web/svelte/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import Details from '$lib/widgets/Details.svelte';
   import UpsertFeedModal from '$lib/widgets/UpsertFeedModal.svelte';
   import AllEntriesWorker from '$lib/workers/all-entries-worker?worker';
+  import { PUBLIC_ENTRIES_API } from '$env/static/public';
 
   onMount(async () => {
     const initialized = await tokenStore.init();
@@ -22,7 +23,7 @@
       if (feeds.length) {
         const urls = feeds.map((feed) => feed.url);
         const allEntriesWorker = new AllEntriesWorker();
-        allEntriesWorker.postMessage(urls);
+        allEntriesWorker.postMessage({ api: PUBLIC_ENTRIES_API, urls });
       }
     });
   });


### PR DESCRIPTION
Fetch all entries in a web worker. Rely on the HTTP cache instead of complicating things unnecessarily with a service worker.

Also switch from local storage to idb so the worker can get the access token conveniently.