### PR TITLE
Fix new indicator

### DIFF
--- a/infra/entries-handler/src/lib/sort-entries.ts
+++ b/infra/entries-handler/src/lib/sort-entries.ts
@@ -16,6 +16,10 @@ export async function sortEntries(unsortedEntries: RssFeedEntries) {
     });
 
     sortedEntries = unsortedEntries.sort((a, b) => {
+      if (a.isNew && b.isNew) {
+        return 0;
+      }
+
       if (a.isNew) {
         return -1;
       }

--- a/infra/entries-lambda.tf
+++ b/infra/entries-lambda.tf
@@ -42,6 +42,13 @@ resource "aws_iam_role_policy" "t-rss-reader-entries-handler-iam-policy" {
     "Version" = "2012-10-17"
     "Statement" = [
       {
+        "Effect" = "Allow",
+        "Action" = [
+          "dynamodb:GetItem",
+        ],
+        "Resource" = "arn:aws:dynamodb:${var.aws-region}:${data.aws_caller_identity.current.account_id}:table/*"
+      },
+      {
         "Effect"   = "Allow",
         "Action"   = "logs:CreateLogGroup",
         "Resource" = "*"

--- a/infra/feeds-lambda.tf
+++ b/infra/feeds-lambda.tf
@@ -45,10 +45,8 @@ resource "aws_iam_role_policy" "t-rss-reader-feeds-handler-iam-policy" {
         "Effect" = "Allow",
         "Action" = [
           "dynamodb:DeleteItem",
-          "dynamodb:GetItem",
           "dynamodb:PutItem",
-          "dynamodb:Scan",
-          "dynamodb:UpdateItem"
+          "dynamodb:Scan"
         ],
         "Resource" = "arn:aws:dynamodb:${var.aws-region}:${data.aws_caller_identity.current.account_id}:table/*"
       },

--- a/web/svelte/src/lib/components/DetailsItem.svelte
+++ b/web/svelte/src/lib/components/DetailsItem.svelte
@@ -12,7 +12,7 @@
   }
 </script>
 
-<li data-new={entry?.isNew}>
+<li data-new={!!entry?.isNew}>
   <a href={entry.url} target="_blank" rel="noopener noreferrer">
     <p class="details-item-title">
       <span class="details-item-is-new" />

--- a/web/svelte/src/lib/components/ListItem.svelte
+++ b/web/svelte/src/lib/components/ListItem.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<li data-elem="list-item" data-selected={selected} data-new={feed?.hasNew} on:click={onSelect}>
+<li data-elem="list-item" data-selected={selected} data-new={!!feed?.hasNew} on:click={onSelect}>
   <div class="list-item-info">
     <p class="list-item-title">
       <span class="list-item-has-new" />

--- a/web/svelte/src/lib/workers/background-request-entries.ts
+++ b/web/svelte/src/lib/workers/background-request-entries.ts
@@ -2,69 +2,31 @@ import EntriesService from '../services/entries-service';
 import LastAccessService from '../services/last-access-service';
 import type { RssFeedEntries } from '$lib/types';
 
-type Urls = Array<string>;
-type UrlResponseMap = Map<string, PromiseSettledResult<Response>>;
-
 function hasNew(entries: RssFeedEntries) {
   return entries.some((entry) => entry?.isNew);
 }
 
-async function makeBackgroundRequests(
-  urls: Urls,
-  entriesService: EntriesService
-): Promise<UrlResponseMap> {
-  const requests = urls.map((url: string) => entriesService.getEntries({ url, timeout: 3000 }));
-  const responses = await Promise.allSettled(requests);
-
-  const urlResponseMap: UrlResponseMap = new Map();
-
-  for (let i = 0; i < urls.length; i++) {
-    urlResponseMap.set(urls[i], responses[i]);
-  }
-
-  return urlResponseMap;
-}
-
-async function notifyFeedsThatHaveNew(urlResponseMap: UrlResponseMap): Promise<Urls> {
-  const feedsWithNewEntries: Set<string> = new Set();
-
-  let unfulfilledUrls: Urls = [];
-
-  for (const [url, response] of urlResponseMap) {
-    if (response.status !== 'fulfilled') {
-      unfulfilledUrls.push(url);
-      continue;
-    }
-
-    if (response.status === 'fulfilled' && response.value) {
-      const entries = await response.value.json();
-
-      if (hasNew(entries)) {
-        const feed = new URL(response.value.url);
-        const url = feed.searchParams.get('url');
-
-        if (url) {
-          feedsWithNewEntries.add(url);
-        }
-      }
-    }
-  }
-
-  if (feedsWithNewEntries) {
-    postMessage(feedsWithNewEntries);
-  }
-
-  return unfulfilledUrls;
-}
-
 /**
- * Request all entries in the background. Effects are:
+ * Request all entries in the background.
  *  - Entries requests are cached so subsequent requests on feed selection are instantaneous
  *  - Feeds can display a new indicator if any entries are new
  */
-async function backgroundRequestEntries(urls: Urls, entriesService: EntriesService): Promise<void> {
-  const urlResponseMap = await makeBackgroundRequests(urls, entriesService);
-  await notifyFeedsThatHaveNew(urlResponseMap);
+async function makeBackgroundRequests(
+  urls: Array<string>,
+  entriesService: EntriesService
+): Promise<void> {
+  const requests = urls.map((url: string) =>
+    entriesService
+      .getEntries({ url, timeout: 10000 })
+      .then((response) => response.json())
+      .then((entries) => {
+        if (hasNew(entries)) {
+          postMessage(url);
+        }
+      })
+  );
+
+  await Promise.allSettled(requests);
 }
 
 onmessage = async (event: MessageEvent): Promise<void> => {
@@ -76,7 +38,7 @@ onmessage = async (event: MessageEvent): Promise<void> => {
 
   const entriesService = new EntriesService(entriesApi);
 
-  await backgroundRequestEntries(urls, entriesService);
+  await makeBackgroundRequests(urls, entriesService);
 
   const lastAccessService: LastAccessService = new LastAccessService(lastAccessApi);
   await lastAccessService.putLastAccess();

--- a/web/svelte/src/routes/+page.svelte
+++ b/web/svelte/src/routes/+page.svelte
@@ -24,10 +24,12 @@
     let backgroundRequestInitialized = false;
 
     backgroundRequestEntriesWorker.onmessage = (event: MessageEvent) => {
-      if (event?.data?.size) {
+      if (event?.data?.startsWith('https')) {
         feedsStore.update((prevFeeds) => {
           const unsortedNextFeeds = prevFeeds.map((prevFeed) => {
-            prevFeed.hasNew = event.data.has(prevFeed.url);
+            if (event.data === prevFeed.url) {
+              prevFeed.hasNew = true
+            }
             return prevFeed;
           });
 


### PR DESCRIPTION
Give `dynamodb:GetItem` policy to entries handler to fix error getting last access time.

Also remove exponential backoff in favor of a smarter approach on each background request completion. Multiple re-renders are fine, a future optimization for large feed lists could be to batch updates if the feed list is above a certain threshold.