### PR TITLE
Implement apple client services

### DIFF
--- a/apple/TRssReader.xcodeproj/project.pbxproj
+++ b/apple/TRssReader.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 		E582AD0629DAA3D70083CCFF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E582AD0529DAA3D70083CCFF /* Constants.swift */; };
 		E582AD0929DAE3250083CCFF /* AuthorizedServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E582AD0829DAE3250083CCFF /* AuthorizedServiceTests.swift */; };
 		E59A4A6629DBC0DD0033B09B /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59A4A6529DBC0DD0033B09B /* Keychain.swift */; };
+		E59A4A6829DE6F680033B09B /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59A4A6729DE6F680033B09B /* LoginService.swift */; };
+		E59A4A6B29DFB19A0033B09B /* URLResponse+StatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59A4A6A29DFB19A0033B09B /* URLResponse+StatusCode.swift */; };
+		E59A4A6D29DFB4440033B09B /* EntriesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59A4A6C29DFB4440033B09B /* EntriesService.swift */; };
+		E59A4A6F29DFBC8A0033B09B /* ServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59A4A6E29DFBC8A0033B09B /* ServiceError.swift */; };
+		E59A4A7129DFBF2B0033B09B /* LastAccessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59A4A7029DFBF2B0033B09B /* LastAccessService.swift */; };
+		E59A4A7329DFC5FF0033B09B /* XCTestCase+XCTAssertErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59A4A7229DFC5FF0033B09B /* XCTestCase+XCTAssertErrorType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +65,12 @@
 		E582AD0529DAA3D70083CCFF /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		E582AD0829DAE3250083CCFF /* AuthorizedServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizedServiceTests.swift; sourceTree = "<group>"; };
 		E59A4A6529DBC0DD0033B09B /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		E59A4A6729DE6F680033B09B /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
+		E59A4A6A29DFB19A0033B09B /* URLResponse+StatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+StatusCode.swift"; sourceTree = "<group>"; };
+		E59A4A6C29DFB4440033B09B /* EntriesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntriesService.swift; sourceTree = "<group>"; };
+		E59A4A6E29DFBC8A0033B09B /* ServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceError.swift; sourceTree = "<group>"; };
+		E59A4A7029DFBF2B0033B09B /* LastAccessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastAccessService.swift; sourceTree = "<group>"; };
+		E59A4A7229DFC5FF0033B09B /* XCTestCase+XCTAssertErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+XCTAssertErrorType.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +121,7 @@
 		E559588E29D4125F008D7307 /* TRssReader */ = {
 			isa = PBXGroup;
 			children = (
+				E59A4A6929DFB0960033B09B /* Extensions */,
 				E582ACF929DA8F430083CCFF /* Configs */,
 				E582ACF029DA805C0083CCFF /* Services */,
 				E582ACEF29DA80270083CCFF /* Utils */,
@@ -137,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				E582AD0729DAE30D0083CCFF /* Services */,
+				E59A4A7229DFC5FF0033B09B /* XCTestCase+XCTAssertErrorType.swift */,
 			);
 			path = TRssReaderTests;
 			sourceTree = "<group>";
@@ -187,6 +201,10 @@
 			children = (
 				E582ACF529DA836A0083CCFF /* FeedsService.swift */,
 				E582AD0329DAA0D70083CCFF /* AuthorizedService.swift */,
+				E59A4A6729DE6F680033B09B /* LoginService.swift */,
+				E59A4A6C29DFB4440033B09B /* EntriesService.swift */,
+				E59A4A6E29DFBC8A0033B09B /* ServiceError.swift */,
+				E59A4A7029DFBF2B0033B09B /* LastAccessService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -204,6 +222,14 @@
 				E582AD0829DAE3250083CCFF /* AuthorizedServiceTests.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		E59A4A6929DFB0960033B09B /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E59A4A6A29DFB19A0033B09B /* URLResponse+StatusCode.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -341,14 +367,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				E549B17B29D6DABE00BF5C45 /* ContentView.swift in Sources */,
+				E59A4A6B29DFB19A0033B09B /* URLResponse+StatusCode.swift in Sources */,
 				E582ACF229DA80980083CCFF /* Feed.swift in Sources */,
 				E582AD0429DAA0D70083CCFF /* AuthorizedService.swift in Sources */,
 				E559589029D4125F008D7307 /* TRssReaderApp.swift in Sources */,
 				E582ACFB29DA8F620083CCFF /* Env.swift in Sources */,
+				E59A4A6D29DFB4440033B09B /* EntriesService.swift in Sources */,
 				E59A4A6629DBC0DD0033B09B /* Keychain.swift in Sources */,
+				E59A4A6F29DFBC8A0033B09B /* ServiceError.swift in Sources */,
 				E582ACF429DA81200083CCFF /* Token.swift in Sources */,
+				E59A4A6829DE6F680033B09B /* LoginService.swift in Sources */,
 				E582ACF629DA836A0083CCFF /* FeedsService.swift in Sources */,
 				E582AD0629DAA3D70083CCFF /* Constants.swift in Sources */,
+				E59A4A7129DFBF2B0033B09B /* LastAccessService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -357,6 +388,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E582AD0929DAE3250083CCFF /* AuthorizedServiceTests.swift in Sources */,
+				E59A4A7329DFC5FF0033B09B /* XCTestCase+XCTAssertErrorType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apple/TRssReader/ContentView.swift
+++ b/apple/TRssReader/ContentView.swift
@@ -16,9 +16,9 @@ struct DetailView: View {
 }
 
 let feeds: [Feed] = [
-    Feed(name: "A", url: "https://a.com", createdAt: "0"),
-    Feed(name: "B", url: "https://b.com", createdAt: "0"),
-    Feed(name: "C", url: "https://c.com", createdAt: "0")
+    Feed(name: "A", url: "https://a.com", createdAt: 0),
+    Feed(name: "B", url: "https://b.com", createdAt: 0),
+    Feed(name: "C", url: "https://c.com", createdAt: 0)
 ]
 
 struct ContentView: View {

--- a/apple/TRssReader/Extensions/URLResponse+StatusCode.swift
+++ b/apple/TRssReader/Extensions/URLResponse+StatusCode.swift
@@ -1,0 +1,18 @@
+//
+//  URLResponse+StatusCode.swift
+//  TRssReader
+//
+//  Created by Ty Hopp on 7/4/23.
+//
+
+import Foundation
+
+extension URLResponse {
+    func statusCode() -> Int {
+        if let code = (self as? HTTPURLResponse)?.statusCode {
+            return code
+        } else {
+            return 500
+        }
+    }
+}

--- a/apple/TRssReader/Models/Feed.swift
+++ b/apple/TRssReader/Models/Feed.swift
@@ -5,14 +5,13 @@
 //  Created by Ty Hopp on 3/4/23.
 //
 
-import Foundation
-
 struct Feed: Codable {
     var name: String
     var url: String
-    var createdAt: String
+    var createdAt: Int
     
     enum CodingKeys: String, CodingKey {
         case name, url, createdAt
     }
 }
+

--- a/apple/TRssReader/Models/Token.swift
+++ b/apple/TRssReader/Models/Token.swift
@@ -5,12 +5,10 @@
 //  Created by Ty Hopp on 3/4/23.
 //
 
-import Foundation
-
 struct Token: Codable {
     var accessToken: String
     var tokenType: String
-    var expiresIn: String
+    var expiresIn: Int
     
     enum CodingKeys: String, CodingKey {
         case accessToken, tokenType, expiresIn

--- a/apple/TRssReader/Services/EntriesService.swift
+++ b/apple/TRssReader/Services/EntriesService.swift
@@ -1,0 +1,18 @@
+//
+//  EntriesService.swift
+//  TRssReader
+//
+//  Created by Ty Hopp on 7/4/23.
+//
+
+import Foundation
+
+class EntriesService: AuthorizedService {
+    @Sendable func getEntries(url: String) async throws -> (Data, URLResponse) {
+        var request = try self.request(api: Env.ENTRIES_API, queryItems: [URLQueryItem(name: "url", value: url)])
+        
+        request.httpMethod = "GET"
+        
+        return try await URLSession.shared.data(for: request)
+    }
+}

--- a/apple/TRssReader/Services/FeedsService.swift
+++ b/apple/TRssReader/Services/FeedsService.swift
@@ -8,17 +8,39 @@
 import Foundation
 
 class FeedsService: AuthorizedService {
-    @Sendable func deleteFeed(url: String) async {
+    @Sendable func deleteFeed(url: String) async throws -> (Data, URLResponse) {
+        var request = try self.request(api: Env.FEEDS_API)
+        
+        request.httpMethod = "DELETE"
+        
         do {
-            var request = self.request(api: Env.FEEDS_API)
-            
-            request.httpMethod = "DELETE"
-            
-            let (data, _) = try await URLSession.shared.data(for: request)
-            
-            print(String(data: data, encoding: .utf8) as Any)
+            request.httpBody = try JSONEncoder().encode(["url": url])
         } catch {
-            print(error)
+            throw ServiceError.encodeBody
         }
+        
+        return try await URLSession.shared.data(for: request)
+    }
+    
+    @Sendable func getFeeds() async throws -> (Data, URLResponse) {
+        var request = URLRequest(url: URL(string: Env.FEEDS_API)!)
+        
+        request.httpMethod = "GET"
+        
+        return try await URLSession.shared.data(for: request)
+    }
+    
+    @Sendable func putFeed(url: String, name: String) async throws -> (Data, URLResponse) {
+        var request = URLRequest(url: URL(string: Env.FEEDS_API)!)
+        
+        request.httpMethod = "PUT"
+        
+        do {
+            request.httpBody = try JSONEncoder().encode(["url": url, "name": name])
+        } catch {
+            throw ServiceError.encodeBody
+        }
+        
+        return try await URLSession.shared.data(for: request)
     }
 }

--- a/apple/TRssReader/Services/LastAccessService.swift
+++ b/apple/TRssReader/Services/LastAccessService.swift
@@ -1,0 +1,18 @@
+//
+//  LastAccessService.swift
+//  TRssReader
+//
+//  Created by Ty Hopp on 7/4/23.
+//
+
+import Foundation
+
+class LastAccessService: AuthorizedService {
+    @Sendable func putLastAccess() async throws -> (Data, URLResponse) {
+        var request = URLRequest(url: URL(string: Env.LAST_ACCESS_API)!)
+        
+        request.httpMethod = "PUT"
+        
+        return try await URLSession.shared.data(for: request)
+    }
+}

--- a/apple/TRssReader/Services/LoginService.swift
+++ b/apple/TRssReader/Services/LoginService.swift
@@ -1,0 +1,24 @@
+//
+//  LoginService.swift
+//  TRssReader
+//
+//  Created by Ty Hopp on 6/4/23.
+//
+
+import Foundation
+
+class LoginService {
+    @Sendable func login(password: String) async throws -> (Data, URLResponse) {
+        guard let url = URL(string: Env.LOGIN_API) else {
+            throw ServiceError.url
+        }
+        
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
+        
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(password, forHTTPHeaderField: "Authorization")
+        request.httpMethod = "POST"
+        
+        return try await URLSession.shared.data(for: request)
+    }
+}

--- a/apple/TRssReader/Services/ServiceError.swift
+++ b/apple/TRssReader/Services/ServiceError.swift
@@ -1,0 +1,13 @@
+//
+//  ServiceError.swift
+//  TRssReader
+//
+//  Created by Ty Hopp on 7/4/23.
+//
+
+enum ServiceError: Error {
+    case url
+    case accessToken
+    case headers
+    case encodeBody
+}

--- a/apple/TRssReader/Utils/Keychain.swift
+++ b/apple/TRssReader/Utils/Keychain.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class Keychain {
-    func getToken() -> AnyObject? {
+    func getToken() -> Token? {
         var token: AnyObject?
         
         let query: [String: AnyObject] = [
@@ -25,6 +25,6 @@ class Keychain {
         // Token copied to memory address if it exists
         SecItemCopyMatching(query as CFDictionary, &token)
         
-        return token
+        return token as? Token
     }
 }

--- a/apple/TRssReaderTests/Services/AuthorizedServiceTests.swift
+++ b/apple/TRssReaderTests/Services/AuthorizedServiceTests.swift
@@ -8,58 +8,104 @@
 import XCTest
 @testable import TRssReader
 
-let mockToken: Token = Token(accessToken: "token", tokenType: "jwt", expiresIn: "0")
+let mockToken: Token = Token(accessToken: "token", tokenType: "jwt", expiresIn: 0)
 
 class AuthorizedServiceTests: XCTestCase {
+    let api = "https://example.com"
+    
+    func testUrlFailure() {
+        let service = AuthorizedService()
+        
+        XCTAssertErrorType(try service.url(api: ""), throws: ServiceError.url)
+    }
+    
+    func testUrlSuccess() {
+        let service = AuthorizedService()
+    
+        let url: URL
+        
+        do {
+            url = try service.url(api: api)
+            
+            XCTAssertEqual(url.absoluteString, api)
+        } catch {
+            XCTFail("Failed to construct url")
+        }
+    }
+    
     func testHeadersNoToken() {
         let service = AuthorizedService(keychain: MockedKeychainNoToken())
-        XCTAssertEqual(service.headers(), service.defaultHeaders)
+        
+        XCTAssertErrorType(try service.headers(), throws: ServiceError.accessToken)
     }
     
     func testHeadersWithToken() {
         let service = AuthorizedService(keychain: MockedKeychainWithToken())
-        var headers = service.headers()
         
-        if let authorization = headers.removeValue(forKey: "Authorization") {
-            XCTAssertTrue(authorization.contains(/accessToken/))
-            XCTAssertEqual(headers, service.defaultHeaders)
+        var headers: [String: String]
+        
+        do {
+            headers = try service.headers()
+            
+            if let authorization = headers.removeValue(forKey: "Authorization") {
+                XCTAssertEqual(authorization, mockToken.accessToken)
+                XCTAssertEqual(headers, service.defaultHeaders)
+            }
+        } catch {
+            XCTFail("Failed to get headers with token")
         }
     }
     
     func testRequestNoToken() {
         let service = AuthorizedService(keychain: MockedKeychainNoToken())
         
-        let api = "https://example.com"
-        let request = service.request(api: api)
-        
-        XCTAssertEqual(request.url?.absoluteString, api)
-        XCTAssertEqual(request.allHTTPHeaderFields, service.defaultHeaders)
+        XCTAssertErrorType(try service.request(api: api), throws: ServiceError.headers)
     }
     
     func testRequestWithToken() {
         let service = AuthorizedService(keychain: MockedKeychainWithToken())
         
-        let api = "https://example.com"
-        let request = service.request(api: api)
-        var headers = request.allHTTPHeaderFields
+        let request: URLRequest
         
-        XCTAssertEqual(request.url?.absoluteString, api)
+        do {
+            request = try service.request(api: api)
+            
+            var headers = request.allHTTPHeaderFields
+            
+            XCTAssertEqual(request.url?.absoluteString, api)
+            
+            if let authorization = headers?.removeValue(forKey: "Authorization") {
+                XCTAssertEqual(authorization, mockToken.accessToken)
+                XCTAssertEqual(headers, service.defaultHeaders)
+            }
+        } catch {
+            XCTFail("Failed to get request with token")
+        }
+    }
+    
+    func testRequestWithQueryItems() {
+        let service = AuthorizedService(keychain: MockedKeychainWithToken())
+        let queryItems = URLQueryItem(name: "a", value: "b")
         
-        if let authorization = headers?.removeValue(forKey: "Authorization") {
-            XCTAssertTrue(authorization.contains(/accessToken/))
-            XCTAssertEqual(headers, service.defaultHeaders)
+        let request: URLRequest
+        
+        do {
+            request = try service.request(api: api, queryItems: [queryItems])
+            XCTAssertEqual(request.url?.absoluteString, "\(api)?a=b")
+        } catch {
+            XCTFail("Failed to get request with query items")
         }
     }
 }
 
 private class MockedKeychainNoToken: Keychain {
-    override func getToken() -> AnyObject? {
-        return [String: String]() as AnyObject
+    override func getToken() -> Token? {
+        return nil
     }
 }
 
 private class MockedKeychainWithToken: Keychain {
-    override func getToken() -> AnyObject? {
-        return try? JSONEncoder().encode(mockToken) as AnyObject
+    override func getToken() -> Token? {
+        return mockToken
     }
 }

--- a/apple/TRssReaderTests/XCTestCase+XCTAssertErrorType.swift
+++ b/apple/TRssReaderTests/XCTestCase+XCTAssertErrorType.swift
@@ -1,0 +1,35 @@
+//
+//  XCTestCase+XCTAssertErrorType.swift
+//  TRssReaderTests
+//
+//  Created by Ty Hopp on 7/4/23.
+//
+
+import XCTest
+
+extension XCTestCase {
+    func XCTAssertErrorType<T, E: Error & Equatable>(
+        _ expression: @autoclosure () throws -> T,
+        throws error: E,
+        in file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        var thrownError: Error?
+
+        XCTAssertThrowsError(try expression(),
+                             file: file, line: line) {
+            thrownError = $0
+        }
+
+        XCTAssertTrue(
+            thrownError is E,
+            "Unexpected error type: \(type(of: thrownError))",
+            file: file, line: line
+        )
+
+        XCTAssertEqual(
+            thrownError as? E, error,
+            file: file, line: line
+        )
+    }
+}


### PR DESCRIPTION
Add implementations for apple client services and improve error handling.

Keep only tests for `AuthorizedService` parent class for now. Add tests for the subclasses after their interfaces are hardened.