### PR TITLE
Use macOS destination in apple CI

### DIFF
--- a/.github/workflows/apple.yaml
+++ b/.github/workflows/apple.yaml
@@ -22,5 +22,4 @@ jobs:
           set -o pipefail && xcodebuild test \
             -project TRssReader.xcodeproj \
             -scheme TRssReaderTests \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14' | xcbeautify
+            -destination 'platform=macOS' | xcbeautify


### PR DESCRIPTION
The macOS destination is much faster than the iOS destination, and the unit tests don't deal with platform-specific APIs yet